### PR TITLE
Add Express backend scaffold

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- set up backend directory for Express server
- add TypeScript config targeting ES2020
- create basic server with `/health` endpoint

## Testing
- `npm init -y`
- `npm install express dotenv` *(fails: 403 Forbidden)*
- `npm install -D typescript ts-node-dev @types/node @types/express` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6853b38ad33c83218a6e4315538ec577