### PR TITLE
Initialize database migrations

### DIFF
--- a/database/migrate.config.js
+++ b/database/migrate.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  schema: 'public',
+  createSchema: true,
+  migrationsTable: 'pgmigrations',
+  migrationFolder: 'migrations',
+  databaseUrl: process.env.DATABASE_URL,
+};

--- a/database/migrations/0001_create_users.js
+++ b/database/migrations/0001_create_users.js
@@ -1,0 +1,12 @@
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.createTable('users', {
+    id: 'id',
+    email: { type: 'text', unique: true },
+  });
+};
+
+exports.down = pgm => {
+  pgm.dropTable('users');
+};

--- a/database/package.json
+++ b/database/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "database",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- initialize Node project in `/database`
- add migrate config reading `DATABASE_URL`
- scaffold first migration for `users` table

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6853b4c2031c8321bdb0b9374671683b