### PR TITLE
Add example env configurations

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgres://user:pass@postgres:5432/awesome_db
+FIREBASE_EMULATOR_HOST=localhost
+FIREBASE_EMULATOR_PORT=8080

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:3001


### PR DESCRIPTION
## Summary
- include .env.example for frontend React settings
- add .env.example for backend defaults

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*
- `npm test --prefix backend` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6853b564a9908321b8757bb8005ab9e7